### PR TITLE
maco as extra dependencies for most of us

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,13 +36,12 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 dependencies = [ "cryptography", "dnfile", "yara-python" ]
+
+optional-dependencies.maco = [ "maco", "validators" ]
 urls."Bug Reports" = "https://github.com/jeFF0Falltrades/rat_king_parser/issues"
 urls."Homepage" = "https://github.com/jeFF0Falltrades/rat_king_parser"
 urls."Say Thanks!" = "https://www.buymeacoffee.com/jeff0falltrades"
 scripts.rat-king-parser = "rat_king_parser:main"
-
-[tool.poetry.extras]
-maco = ["maco", "validators"]
 
 [tool.setuptools.dynamic]
 version = { attr = "rat_king_parser._version.__version__" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,14 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dynamic = [ "version" ]
-dependencies = [ "cryptography", "dnfile", "maco", "validators", "yara-python" ]
+dependencies = [ "cryptography", "dnfile", "yara-python" ]
 urls."Bug Reports" = "https://github.com/jeFF0Falltrades/rat_king_parser/issues"
 urls."Homepage" = "https://github.com/jeFF0Falltrades/rat_king_parser"
 urls."Say Thanks!" = "https://www.buymeacoffee.com/jeff0falltrades"
 scripts.rat-king-parser = "rat_king_parser:main"
+
+[tool.poetry.extras]
+maco = ["maco", "validators"]
 
 [tool.setuptools.dynamic]
 version = { attr = "rat_king_parser._version.__version__" }


### PR DESCRIPTION
hello, could we put maco as side dependencies to reduce number of extra dependencies for those who doesn't need it?

it just become to be installed with rkp["maco"]