### PR TITLE
Account for cases where a single port was extracted from the configuration

### DIFF
--- a/src/rat_king_parser/extern/maco/rkp_maco.py
+++ b/src/rat_king_parser/extern/maco/rkp_maco.py
@@ -102,13 +102,18 @@ class RKPMACO(extractor.Extractor):
                     # Instead, these will show individually as "server_port"
                     # entries in the MACO config
                     case ConfigValueTypes.PORT:
-                        rkp_model.tcp.extend(
-                            [
-                                rkp_model.Connection(server_port=port)
-                                for port in v
-                                if port.isdigit()
-                            ]
-                        )
+                        if isinstance(v, int):
+                            # Single port was extracted rather than a list
+                            rkp_model.tcp.append(rkp_model.Connection(server_port=v))
+                        else:
+                            # Assume a list of ports was extracted
+                            rkp_model.tcp.extend(
+                                [
+                                    rkp_model.Connection(server_port=port)
+                                    for port in v
+                                    if port.isdigit()
+                                ]
+                            )
                     case ConfigValueTypes.VERSION:
                         rkp_model.version = v
                 continue


### PR DESCRIPTION
Hey again! 🤓

Found an issue with RKP Maco running on this sample: https://www.virustotal.com/gui/file/34b7f3aaf23df873caa0ea4e9d28e5362fe5ca4a535b53ae3b16ce4676ac8b1b