### PR TITLE
Minor changes on top of small_optimizations PR

### DIFF
--- a/src/rat_king_parser/config_parser/rat_config_parser.py
+++ b/src/rat_king_parser/config_parser/rat_config_parser.py
@@ -171,9 +171,8 @@ class RATConfigParser:
                 logger.debug(f"Decryption failed with decryptor {decryptor} : {e}")
                 self._decryptor = None
 
-        if self._decryptor is None:
-            raise ConfigParserException("All decryptors failed")
-        return item_data
+        # If we exit the loop without returning, no decryptor succeeded
+        raise ConfigParserException("All decryptors failed")
 
     def _remap_config(
         self, decoded_config: dict[str, Any], config_fields_map: dict[int, str]

--- a/src/rat_king_parser/config_parser/utils/config_normalization.py
+++ b/src/rat_king_parser/config_parser/utils/config_normalization.py
@@ -39,16 +39,23 @@ normalized_keys = {
     "Group": ("Group", "Groub", "GroupTag", "TAG"),
 }
 
+# Strip underscores from aliases at build time so the lookup is consistent
+# with the underscore-stripped input key (e.g. so "mutex_string" actually
+# resolves to "Mutex")
 _normalized_keys_map = {
-    alias: k for k, aliases in normalized_keys.items() for alias in aliases
+    alias.replace("_", ""): k
+    for k, aliases in normalized_keys.items()
+    for alias in aliases
 }
 
 
 # Normalizes config keys/values for easier mapping
 def check_key_n_value(key: str, value: Any) -> tuple[str, Any]:
-    key_clean = key.replace("_", "")
-    if key_clean in _normalized_keys_map:
-        key = _normalized_keys_map[key_clean]
+    # Always strip underscores from the returned key to preserve the prior
+    # behavior of this function for unrecognized keys
+    key = key.replace("_", "")
+    if key in _normalized_keys_map:
+        key = _normalized_keys_map[key]
 
     if key in ("Hosts", "Ports") and isinstance(value, str):
         if value not in ("null", "false"):

--- a/src/rat_king_parser/config_parser/utils/decryptors/config_decryptor_aes_with_iv.py
+++ b/src/rat_king_parser/config_parser/utils/decryptors/config_decryptor_aes_with_iv.py
@@ -111,7 +111,8 @@ class ConfigDecryptorAESWithIV(ConfigDecryptor):
 
     # Decrypts encrypted config values with the provided cipher data
     def decrypt_encrypted_strings(
-        self, encrypted_strings: dict[str, str]) -> dict[str, str]:
+        self, encrypted_strings: dict[str, str]
+    ) -> dict[str, str]:
         logger.debug("Decrypting encrypted strings...")
         if self._key_candidates is None:
             self._key_candidates = self._get_aes_key_candidates(encrypted_strings)
@@ -193,7 +194,8 @@ class ConfigDecryptorAESWithIV(ConfigDecryptor):
 
     # Extracts AES key candidates from the payload
     def _get_aes_key_candidates(
-        self, encrypted_strings: dict[str, str]) -> list[bytes]:
+        self, encrypted_strings: dict[str, str]
+    ) -> list[bytes]:
         logger.debug("Extracting AES key candidates...")
         keys = []
 
@@ -284,7 +286,9 @@ class ConfigDecryptorAESWithIV(ConfigDecryptor):
         if not self._metadata_candidates:
             raise ConfigParserException("Could not identify AES metadata")
 
-        # Extraction of common metadata
+        # Key size, block size, and algo are properties of the embedded AES
+        # class definition, not of any single salt/iter candidate, so they are
+        # extracted once and shared across all metadata candidates
         self._key_size, self._block_size, self._aes_algo = (
             self._get_aes_key_and_block_size_and_algo()
         )

--- a/src/rat_king_parser/config_parser/utils/decryptors/config_decryptor_aes_with_iv.py
+++ b/src/rat_king_parser/config_parser/utils/decryptors/config_decryptor_aes_with_iv.py
@@ -118,6 +118,7 @@ class ConfigDecryptorAESWithIV(ConfigDecryptor):
             self._key_candidates = self._get_aes_key_candidates(encrypted_strings)
 
         decrypted_config_strings = {}
+        attempted_decryptions = 0
         successfully_decrypted_count = 0
         successful_key = None
 
@@ -141,9 +142,11 @@ class ConfigDecryptorAESWithIV(ConfigDecryptor):
                 decrypted_config_strings[k] = v
                 continue
 
-            # Otherwise, extract the IV from the 16 bytes after the HMAC
-            # (first 32 bytes) and the ciphertext from the rest of the data
-            # after the IV, and run the decryption
+            # Past this point we are actually attempting a decryption
+            attempted_decryptions += 1
+            # Extract the IV from the 16 bytes after the HMAC (first 32 bytes)
+            # and the ciphertext from the rest of the data after the IV, and
+            # run the decryption
             iv, ciphertext = decoded_val[32:48], decoded_val[48:]
             result, last_exc = None, None
 
@@ -180,7 +183,12 @@ class ConfigDecryptorAESWithIV(ConfigDecryptor):
             logger.debug(f"Key: {k}, Value: {result}")
             decrypted_config_strings[k] = result
 
-        if successfully_decrypted_count == 0:
+        # Only raise if we actually tried to decrypt at least one string and
+        # none succeeded. Template/builder samples have 0 attempts (all values
+        # are placeholders that fail the b64/length filter above), and should
+        # fall through cleanly so this AES decryptor remains the active one
+        # and its salt is still reported.
+        if attempted_decryptions > 0 and successfully_decrypted_count == 0:
             raise ConfigParserException(
                 "No strings could be decrypted with the available keys"
             )


### PR DESCRIPTION
 ## Summary

  Follow-up changes on top of #44:

  - **`config_normalization`**: Strip underscores from alias keys at map-build time so aliases like `mutex_string` actually resolve to `Mutex`. Restore unconditional underscore-stripping on the returned key to
   preserve the prior behavior for unrecognized keys.
  - **`rat_config_parser._attempt_decryption`**: Replace the unreachable conditional trailing `return` with an unconditional `raise` to make the "decrypt-or-raise" invariant explicit.
  - **`config_decryptor_aes_with_iv`**: Restore the `-> list[bytes]` and `-> dict[str, str]` return type hints that were dropped during reformatting, and document why `key_size`/`block_size`/`algo` are
  extracted once and shared across all metadata candidates.
  - **`config_decryptor_aes_with_iv.decrypt_encrypted_strings`**: Fix a regression introduced in #44 where the new `successfully_decrypted_count == 0` guard caused template/builder samples (e.g. unconfigured
  AsyncRAT builds whose config values are all placeholders like `%Anti%`) to fall through to the plaintext decryptor and lose the reported `salt`. Now tracks attempted decryptions separately and only raises when at least one decryption was attempted and all attempts failed.